### PR TITLE
Unifica pacote rag.retrieval e ajusta execução do Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ COPY --from=builder --chown=appuser:appuser /build/venv /opt/venv
 
 # Define diretório de trabalho
 WORKDIR /opt/az
+ENV PYTHONPATH="/opt/az/src/main/python:${PYTHONPATH}"
 
 # Copia código da aplicação
 COPY --chown=appuser:appuser . .
@@ -88,4 +89,4 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["gunicorn", \
      "--config", "gunicorn.conf.py", \
      "--bind", "0.0.0.0:5002", \
-     "src.main.python.applicationApi:app"]
+     "applicationApi:app"]

--- a/src/main/python/rag/retrieval/__init__.py
+++ b/src/main/python/rag/retrieval/__init__.py
@@ -1,2 +1,34 @@
-# Marca o diretório como pacote Python.
+"""
+Pacote de retrieval unificado.
 
+- Mantém compatibilidade com imports legados, ex.:
+    from rag.retrieval import get_retrieval_instance, search_requirements
+- Reexporta símbolos definidos em .hybrid (antigo retrieval.py)
+- FAISS segue opcional; se não instalado, BM25 permanece como fallback.
+"""
+
+# Reexporta API pública do módulo 'hybrid' (antigo retrieval.py)
+from .hybrid import (
+    RAGRetrieval,
+    get_retrieval_instance,
+    search_requirements,
+    build_indices,
+    search_legal,
+    # ↳ adicione aqui quaisquer outros símbolos públicos que antes vinham de rag.retrieval
+)
+
+# Exporta FaissIndex se disponível (não obrigatório)
+try:
+    from .faiss_index import FaissIndex  # noqa: F401
+except Exception:  # pragma: no cover - módulo opcional
+    # FAISS não instalado → sem erro; pacote segue funcional via BM25
+    FaissIndex = None  # type: ignore[assignment]
+
+__all__ = [
+    "RAGRetrieval",
+    "get_retrieval_instance",
+    "search_requirements",
+    "build_indices",
+    "search_legal",
+    "FaissIndex",
+]

--- a/src/main/python/rag/retrieval/hybrid.py
+++ b/src/main/python/rag/retrieval/hybrid.py
@@ -563,3 +563,4 @@ def search_legal(objective_slug: str, query: str, k: int = 8) -> List[Dict]:
     """Função de conveniência para busca de normas legais"""
     retrieval = get_retrieval_instance()
     return retrieval.search_legal(objective_slug, query, k)
+


### PR DESCRIPTION
## Summary
- move o módulo legado de retrieval para rag/retrieval/hybrid.py e passa a reexportar a API pública no novo __init__
- mantém compatibilidade de imports (get_retrieval_instance, search_requirements, etc.) e exporta FaissIndex de forma opcional
- configura o PYTHONPATH no Dockerfile e aponta o Gunicorn para applicationApi:app

## Testing
- PYTHONPATH=src/main/python OPENAI_API_KEY=dummy SECRET_KEY=test DATABASE_URL=postgresql+psycopg2://user:pass@localhost:5432/db EMBEDDINGS_PROVIDER=openai DB_VENDOR=postgresql AUTO_INGEST_ON_BOOT=false DB_CREATE_ALL=false python - <<'PY'\nimport applicationApi\nprint("has_app:", hasattr(applicationApi, "app"))\nPY
- PYTHONPATH=src/main/python python - <<'PY'\nfrom rag.retrieval import get_retrieval_instance, search_requirements\nprint(callable(get_retrieval_instance), callable(search_requirements))\nPY
- docker build -t autodoc:test . *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e49730f34483319d39c7b107b3c0da