### PR TITLE
Adjust Liquibase configuration parsing variable

### DIFF
--- a/src/main/python/application/config/liquibase_config.py
+++ b/src/main/python/application/config/liquibase_config.py
@@ -17,7 +17,7 @@ def get_configuracao_liquibase() -> Dict[str, Any]:
 
     match = re.match(r'postgresql(\+psycopg2)?://([^:]+):([^@]+)@([^:]+):(\d+)/(.+)', db_url)
     if match:
-        _, username, password, host, port, database = match.groups()
+        _, username, password, host, port, _database = match.groups()
     else:
         raise ValueError(
             "DATABASE_URL deve estar no formato PostgreSQL válido: "


### PR DESCRIPTION
## Summary
- avoid keeping an unused variable when parsing the DATABASE_URL for Liquibase configuration

## Testing
- PYTHONPATH=src/main/python python - <<'PY'
import compileall, sys
ok = compileall.compile_dir('src/main/python', force=True, quiet=1)
sys.exit(0 if ok else 1)
PY
- OPENAI_API_KEY=dummy SECRET_KEY=secret DATABASE_URL=postgresql+psycopg2://user:pass@localhost:5432/db EMBEDDINGS_PROVIDER=openai PYTHONPATH=src/main/python python - <<'PY'
import applicationApi
print("has_app:", hasattr(applicationApi, "app"))
PY
- PYTHONPATH=src/main/python python - <<'PY'
from rag.retrieval import get_retrieval_instance, search_requirements, FaissIndex
print(callable(get_retrieval_instance), callable(search_requirements), isinstance(FaissIndex, type) or FaissIndex is None)
PY
- OPENAI_API_KEY=dummy SECRET_KEY=secret DATABASE_URL=postgresql+psycopg2://user:pass@localhost:5432/db EMBEDDINGS_PROVIDER=openai ENABLE_METRICS=false PYTHONPATH=src/main/python python - <<'PY'
from applicationApi import create_app
app = create_app()
print('metrics_route_present', any(rule.rule == '/metrics' for rule in app.url_map.iter_rules()))
PY
- OPENAI_API_KEY=dummy SECRET_KEY=secret DATABASE_URL=postgresql+psycopg2://user:pass@localhost:5432/db EMBEDDINGS_PROVIDER=openai ENABLE_METRICS=true METRICS_TOKEN=testtoken PYTHONPATH=src/main/python python - <<'PY'
from applicationApi import create_app
app = create_app()
with app.test_client() as client:
    resp = client.get('/metrics', headers={'Authorization': 'Bearer testtoken'})
    print('status', resp.status_code)
PY

------
https://chatgpt.com/codex/tasks/task_e_68e51578a7f08331bae2c863a4db6d3d